### PR TITLE
Render document root description using markdown

### DIFF
--- a/index.nunjucks
+++ b/index.nunjucks
@@ -53,7 +53,9 @@
 						<h1 class="rtc__title">{{ title }} <span class="version">v{{ version }}</span></h1>
 
 						{% if description %}
-						<p class="rtc__description">{{ description }}</p>
+						<div class="rtc__description">
+							{% markdown %} {{ description }} {% endmarkdown %}
+						</div>
 						{% endif %}
 
 						<p class="rtc__base-uri">


### PR DESCRIPTION
According to RAML 1.0, the document root's description MAY be formatted
using markdown [1]_. This patch replaces the (optional) `<p>` element
with a `<div>` element containing rendered markdown.

.. [1] RAML 1.0
https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#the-root-of-the-document